### PR TITLE
Restrict personal best lap to configured driver

### DIFF
--- a/irmain.py
+++ b/irmain.py
@@ -113,7 +113,15 @@ def main():
                 )
 
                 qbest_lap = best_lap(qinfo)
-                rbest_lap = best_lap(rinfo)
+                rbest_lap = next(
+                    (
+                        lap
+                        for lap in rinfo
+                        if lap.get("display_name") == ir_drivername
+                        and lap.get("personal_best_lap")
+                    ),
+                    None,
+                )
 
                 qbest_time = qbest_lap["lap_time"] if qbest_lap else None
                 rbest_time = rbest_lap["lap_time"] if rbest_lap else None


### PR DESCRIPTION
## Summary
- limit the `rbest_lap` lookup to laps where the driver name matches `d_name`

## Testing
- `python -m py_compile irmain.py ir_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6859a4d2f6dc8326ba6455012d5720ec