### PR TITLE
Add average lap time support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ CREATE TABLE `iRacing` (
   `Track` varchar(255) DEFAULT NULL,
   `QualifyingTime` int(20) DEFAULT NULL,
   `RaceTime` int(20) DEFAULT NULL,
+  `AverageLapTime` int(20) DEFAULT NULL,
   `Incidents` int(3) DEFAULT NULL,
   `OldSafetyRating` decimal(3,2) DEFAULT NULL,
   `NewSafetyRating` decimal(3,2) DEFAULT NULL,

--- a/irmain.py
+++ b/irmain.py
@@ -56,19 +56,23 @@ def best_lap(info):
     return next((lap for lap in info if lap["personal_best_lap"]), None)
 
 
-def driver_new_licence(client: irDataClient, subsession_id: int, driver_name: str) -> str | None:
+def driver_new_licence(
+    client: irDataClient, subsession_id: int, driver_name: str
+) -> str | None:
     """Return the licence letter for the driver in a given subsession."""
     result = client.result(subsession_id=subsession_id)
-    for session in result.get("session_results", []):
-        for entry in session.get("results", []):
-            drivers = entry.get("driver_results")
-            if drivers is None:
-                if entry.get("display_name") == driver_name:
-                    return licence_from_level(entry.get("new_license_level"))
-            else:
-                for driver in drivers:
-                    if driver.get("display_name") == driver_name:
-                        return licence_from_level(driver.get("new_license_level"))
+    sessions = result.get("session_results", [])
+    if len(sessions) <= 2:
+        return None
+    for entry in sessions[2].get("results", []):
+        drivers = entry.get("driver_results")
+        if drivers is None:
+            if entry.get("display_name") == driver_name:
+                return licence_from_level(entry.get("new_license_level"))
+        else:
+            for driver in drivers:
+                if driver.get("display_name") == driver_name:
+                    return licence_from_level(driver.get("new_license_level"))
     return None
 
 

--- a/irmain.py
+++ b/irmain.py
@@ -77,16 +77,18 @@ def driver_average_lap(
 ) -> int | None:
     """Return the average lap time for the driver in a given subsession."""
     result = client.result(subsession_id=subsession_id)
-    for session in result.get("session_results", []):
-        for entry in session.get("results", []):
-            drivers = entry.get("driver_results")
-            if drivers is None:
-                if entry.get("display_name") == driver_name:
-                    return entry.get("average_lap")
-            else:
-                for driver in drivers:
-                    if driver.get("display_name") == driver_name:
-                        return driver.get("average_lap")
+    sessions = result.get("session_results", [])
+    if len(sessions) <= 2:
+        return None
+    for entry in sessions[2].get("results", []):
+        drivers = entry.get("driver_results")
+        if drivers is None:
+            if entry.get("display_name") == driver_name:
+                return entry.get("average_lap")
+        else:
+            for driver in drivers:
+                if driver.get("display_name") == driver_name:
+                    return driver.get("average_lap")
     return None
 
 


### PR DESCRIPTION
## Summary
- capture driver's average lap time from `client.result`
- store average lap time in new DB column `AverageLapTime`
- update README schema with `AverageLapTime`

## Testing
- `python -m py_compile irmain.py ir_utils.py testing.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0d3b36b08326b547ca5bf04c42dd