### PR TITLE
Fix track config fallback logging

### DIFF
--- a/irmain.py
+++ b/irmain.py
@@ -252,13 +252,22 @@ def main():
                 licence = driver_new_licence(race_result, ir_drivername)
                 avg_lap_time = driver_average_lap(race_result, ir_drivername)
 
+                track_configuration = race.get("track", {}).get("config_name")
+                if not track_configuration:
+                    track_configuration = race.get("track", {}).get("track_name")
+                    logging.info(
+                        "No config_name for subsession %s; using track_name '%s'",
+                        subsession_id,
+                        track_configuration,
+                    )
+
                 values = (
                     subsession_id,
                     session_time,
                     race["series_name"],
                     car_name(race["car_id"], cars_by_id),
                     race["track"]["track_name"],
-                    race["track"]["config_name"],
+                    track_configuration,
                     qbest_time if qbest_time else "0",
                     rbest_time if rbest_time else "0",
                     avg_lap_time if avg_lap_time is not None else "0",


### PR DESCRIPTION
## Summary
- log when `config_name` is missing and `track_name` is used

## Testing
- `python -m py_compile irmain.py ir_utils.py time_convert.py update_carlist.py`


------
https://chatgpt.com/codex/tasks/task_e_686f91e76c9083269a25db6b21a0a0dd