### PR TITLE
Record DNF from race results

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ CREATE TABLE `iRacing` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
 ```
 
-The `DnF` column is set to `true` when the session results show a `reason_out`
-value other than `Running`; otherwise it is `false`.
+The `DnF` column is `false` only when `reason_out` is `Running`; for any other
+value it is `true`.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,6 @@ CREATE TABLE `iRacing` (
   PRIMARY KEY (`subsessionId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci;
 ```
+
+The `DnF` column is set to `true` when the session results show a `reason_out`
+value other than `Running`; otherwise it is `false`.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ CREATE TABLE `iRacing` (
   `LapsLed` int(4) DEFAULT NULL,
   `Points` int(4) DEFAULT NULL,
   `SoF` int(5) DEFAULT NULL,
+  `DnF` char(5) DEFAULT NULL,
   `RaceType` varchar(25) DEFAULT NULL,
   `TeamRace` char(5) DEFAULT NULL,
   `QualiSetByTeammate` char(5) DEFAULT NULL,

--- a/irmain.py
+++ b/irmain.py
@@ -95,6 +95,14 @@ def driver_average_lap(result: dict, driver_name: str) -> int | None:
     return None
 
 
+def driver_dnf(result: dict, driver_name: str) -> bool:
+    """Return True if the driver did not finish the race."""
+    driver = _find_driver_result(result, driver_name)
+    if driver is not None:
+        return driver.get("reason_out") != "Running"
+    return False
+
+
 def car_name(car_id: int, lookup: dict) -> str:
     """Return the car name for the given id."""
     return lookup.get(car_id, "No car with that ID.")
@@ -192,9 +200,9 @@ def main():
                     subsessionId, SessionDate, SeriesName, Car, Track, TrackConfiguration,
                     QualifyingTime, RaceTime, AverageLapTime, Incidents, OldSafetyRating, NewSafetyRating, SafetyRatingGain, Licence,
                     StartPosition, FinishPosition, OldiRating, NewiRating, iRatingGain, Laps, LapsLed,
-                    Points, SoF, RaceType, TeamRace, QualiSetByTeammate, FastestLapSetByTeammate,
+                    Points, SoF, DnF, RaceType, TeamRace, QualiSetByTeammate, FastestLapSetByTeammate,
                     SeasonWeek, SeasonNumber, SeasonYear
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """
 
             for race in recent_races["races"]:
@@ -252,6 +260,7 @@ def main():
                 licence = driver_new_licence(race_result, ir_drivername)
                 avg_lap_time = driver_average_lap(race_result, ir_drivername)
                 track_config = race_result.get("track", {}).get("config_name")
+                dnf = driver_dnf(race_result, ir_drivername)
 
                 values = (
                     subsession_id,
@@ -277,6 +286,7 @@ def main():
                     race["laps_led"],
                     race["points"],
                     race["strength_of_field"],
+                    str(dnf).lower(),
                     race_type,
                     str(is_teamrace).lower(),
                     str(q_set_by_teammate).lower(),

--- a/irmain.py
+++ b/irmain.py
@@ -95,13 +95,10 @@ def driver_average_lap(result: dict, driver_name: str) -> int | None:
     return None
 
 
-def driver_dnf(result: dict, driver_name: str) -> bool:
+def driver_dnf(race: dict) -> bool:
     """Return True if the driver did not finish the race."""
-    driver = _find_driver_result(result, driver_name)
-    if driver is not None:
-        reason = driver.get("reason_out") or ""
-        return reason.strip().lower() != "running"
-    return False
+    reason = race.get("reason_out") or ""
+    return reason.strip().lower() != "running"
 
 
 def car_name(car_id: int, lookup: dict) -> str:
@@ -261,7 +258,7 @@ def main():
                 licence = driver_new_licence(race_result, ir_drivername)
                 avg_lap_time = driver_average_lap(race_result, ir_drivername)
                 track_config = race_result.get("track", {}).get("config_name")
-                dnf = driver_dnf(race_result, ir_drivername)
+                dnf = driver_dnf(race)
 
                 values = (
                     subsession_id,

--- a/irmain.py
+++ b/irmain.py
@@ -99,7 +99,8 @@ def driver_dnf(result: dict, driver_name: str) -> bool:
     """Return True if the driver did not finish the race."""
     driver = _find_driver_result(result, driver_name)
     if driver is not None:
-        return driver.get("reason_out") != "Running"
+        reason = driver.get("reason_out") or ""
+        return reason.strip().lower() != "running"
     return False
 
 


### PR DESCRIPTION
## Summary
- add helper to detect DNF based on `reason_out`
- store DNF flag when inserting race results
- document DNF column in README

## Testing
- `python -m py_compile irmain.py`


------
https://chatgpt.com/codex/tasks/task_e_6895c02646748326bf7c24e0bf737dd0