### PR TITLE
Add DnF flag derived from result reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ CREATE TABLE `iRacing` (
   `iRatingGain` int(3) DEFAULT NULL,
   `Laps` int(4) DEFAULT NULL,
   `LapsLed` int(4) DEFAULT NULL,
+  `DnF` char(5) DEFAULT NULL,
   `Points` int(4) DEFAULT NULL,
   `SoF` int(5) DEFAULT NULL,
   `RaceType` varchar(25) DEFAULT NULL,

--- a/irmain.py
+++ b/irmain.py
@@ -105,6 +105,16 @@ def driver_average_lap(
     return None
 
 
+def driver_reason_out(
+    result: dict, driver_name: str, member_id: str
+) -> str | None:
+    """Return the reason a driver left the race."""
+    driver = _find_driver_result(result, driver_name, member_id)
+    if driver is not None:
+        return driver.get("reason_out")
+    return None
+
+
 def car_name(car_id: int, lookup: dict) -> str:
     """Return the car name for the given id."""
     return lookup.get(car_id, "No car with that ID.")
@@ -260,13 +270,13 @@ def main():
                 session_time = format_session_time(race["session_start_time"])
                 race_result = client.result(subsession_id=subsession_id)
                 licence = driver_new_licence(race_result, ir_drivername, ir_mem_id)
-                avg_lap_time = driver_average_lap(race_result, ir_drivername, ir_mem_id)
-                driver_info = _find_driver_result(race_result, ir_drivername, ir_mem_id)
-                dnf = (
-                    driver_info.get("reason_out") not in (None, "", "Running")
-                    if driver_info
-                    else False
+                avg_lap_time = driver_average_lap(
+                    race_result, ir_drivername, ir_mem_id
                 )
+                reason_out = driver_reason_out(
+                    race_result, ir_drivername, ir_mem_id
+                )
+                dnf = reason_out not in (None, "", "Running")
                 track_config = race_result.get("track", {}).get("config_name")
 
                 values = (

--- a/irmain.py
+++ b/irmain.py
@@ -191,10 +191,10 @@ def main():
                 INSERT INTO iRacing (
                     subsessionId, SessionDate, SeriesName, Car, Track, TrackConfiguration,
                     QualifyingTime, RaceTime, AverageLapTime, Incidents, OldSafetyRating, NewSafetyRating, SafetyRatingGain, Licence,
-                    StartPosition, FinishPosition, OldiRating, NewiRating, iRatingGain, Laps, LapsLed,
+                    StartPosition, FinishPosition, OldiRating, NewiRating, iRatingGain, Laps, LapsLed, DnF,
                     Points, SoF, RaceType, TeamRace, QualiSetByTeammate, FastestLapSetByTeammate,
                     SeasonWeek, SeasonNumber, SeasonYear
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """
 
             for race in recent_races["races"]:
@@ -251,6 +251,8 @@ def main():
                 race_result = client.result(subsession_id=subsession_id)
                 licence = driver_new_licence(race_result, ir_drivername)
                 avg_lap_time = driver_average_lap(race_result, ir_drivername)
+                driver_info = _find_driver_result(race_result, ir_drivername)
+                dnf = driver_info.get("reason_out") != "Running" if driver_info else False
                 track_config = race_result.get("track", {}).get("config_name")
 
                 values = (
@@ -275,6 +277,7 @@ def main():
                     ir_gain,
                     race["laps"],
                     race["laps_led"],
+                    str(dnf).lower(),
                     race["points"],
                     race["strength_of_field"],
                     race_type,


### PR DESCRIPTION
## Summary
- track driver did-not-finish status via `reason_out`
- store DnF flag in database insert and document column

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895cac952c8832692402d42357aca42