### PR TITLE
Add DnF flag from race results

### DIFF
--- a/irmain.py
+++ b/irmain.py
@@ -254,7 +254,12 @@ def main():
                 track_config = race_result.get("track", {}).get("config_name")
 
                 session_results = race_result.get("session_results", {})
-                race_session = session_results.get("1") or session_results.get(1) or {}
+                if isinstance(session_results, dict):
+                    race_session = session_results.get("1") or session_results.get(1) or {}
+                elif isinstance(session_results, list):
+                    race_session = session_results[2] if len(session_results) > 2 else {}
+                else:
+                    race_session = {}
                 results_list = race_session.get("results", [])
                 member_result = next(
                     (res for res in results_list if str(res.get("cust_id")) == str(ir_mem_id)),


### PR DESCRIPTION
## Summary
- derive DnF flag from session results based on member's reason_out
- store DnF in database between RaceType and TeamRace columns

## Testing
- `python -m py_compile irmain.py`


------
https://chatgpt.com/codex/tasks/task_e_6896fc06bdd48326bdc4fca9738629b1